### PR TITLE
MGF error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+/.project
+/.pydevproject

--- a/tools/generate_spectrum_index/generate_spectrum_index.py
+++ b/tools/generate_spectrum_index/generate_spectrum_index.py
@@ -13,6 +13,8 @@ def arguments():
     parser.add_argument('-i','--input_spectrum', type = str, help='Single spectrum file of types mzML, mzXML, or mgf.')
     parser.add_argument('-o','--output_folder', type = str, help='Folder to write out tab-separated index file to write out')
     parser.add_argument('-l','--default_ms_level', type = str, help='Default MSlevel')
+    parser.add_argument('-e','--suppress_error_text', help='Suppress Errors in Output', dest='suppress_errors', action='store_true')
+    parser.set_defaults(suppress_errors=False)
     if len(sys.argv) < 2:
         parser.print_help()
         sys.exit(1)
@@ -38,60 +40,78 @@ def main():
     mgf_ms1_warn = False
 
     if input_filetype == '.mzXML':
-        with open(input, 'rb') as mzxml_file:
-            with mzxml.read(mzxml_file) as reader:
-                for s in reader:
-                    # Always use scan= for nativeID for mzXML
-                    spectra.append(Spectrum('scan={}'.format(s['num']),int(s['msLevel']),-1 if int(s['msLevel']) == 1 else ms2plus_scan_idx))
-                    # Increment MS2+ counter, if spectrum was MS2+
-                    if int(s.get('msLevel',2)) > 1:
-                        ms2plus_scan_idx += 1
+        try:
+            with open(input, 'rb') as mzxml_file:
+                with mzxml.read(mzxml_file) as reader:
+                    for s in reader:
+                        # Always use scan= for nativeID for mzXML
+                        spectra.append(Spectrum('scan={}'.format(s['num']),int(s['msLevel']),-1 if int(s['msLevel']) == 1 else ms2plus_scan_idx))
+                        # Increment MS2+ counter, if spectrum was MS2+
+                        if int(s.get('msLevel',2)) > 1:
+                            ms2plus_scan_idx += 1
+        except Error as e:
+            if suppress_errors:
+                print("{} is an malformatted {} file.".format(input,input_filetype))
+            else:
+                raise e
     elif input_filetype == '.mzML':
-        with open(input, 'rb') as mzml_file:
-            mzml_object = mzml.read(mzml_file)
-            param_groups = {}
-            for ref in mzml_object.iterfind("referenceableParamGroupList/referenceableParamGroup"):
-                param_groups[ref['id']] = ref
-        with open(input, 'rb') as mzml_file:
-            with mzml.read(mzml_file) as reader:
-                for s in reader:
-                    ms_level = s.get('ms level')
-                    if not ms_level:
-                        spec_param_group = s.get('ref')
-                        if spec_param_group:
-                            ms_level = param_groups[spec_param_group].get('ms level')
-                        elif args.default_ms_level:
-                            ms_level = args.default_ms_level
-                        else:
-                            raise Exception("No ms level found and no default for input.")
-                    # Always use given nativeID for mzML
-                    spectra.append(Spectrum(s['id'],int(ms_level),-1 if int(ms_level) == 1 else ms2plus_scan_idx))
-                    # Increment MS2+ counter, if spectrum was MS2+
-                    if int(ms_level) > 1:
-                        ms2plus_scan_idx += 1
+        try:
+            with open(input, 'rb') as mzml_file:
+                mzml_object = mzml.read(mzml_file)
+                param_groups = {}
+                for ref in mzml_object.iterfind("referenceableParamGroupList/referenceableParamGroup"):
+                    param_groups[ref['id']] = ref
+            with open(input, 'rb') as mzml_file:
+                with mzml.read(mzml_file) as reader:
+                    for s in reader:
+                        ms_level = s.get('ms level')
+                        if not ms_level:
+                            spec_param_group = s.get('ref')
+                            if spec_param_group:
+                                ms_level = param_groups[spec_param_group].get('ms level')
+                            elif args.default_ms_level:
+                                ms_level = args.default_ms_level
+                            else:
+                                raise Exception("No ms level found and no default for input.")
+                        # Always use given nativeID for mzML
+                        spectra.append(Spectrum(s['id'],int(ms_level),-1 if int(ms_level) == 1 else ms2plus_scan_idx))
+                        # Increment MS2+ counter, if spectrum was MS2+
+                        if int(ms_level) > 1:
+                            ms2plus_scan_idx += 1
+        except Error as e:
+            if suppress_errors:
+                raise("{} is an malformatted {} file.".format(input,input_filetype))
+            else:
+                raise e
     elif input_filetype == '.mzML.gz':
-        with gzip.open(input, 'rb') as mzmlgz_file:
-            mzml_object = mzml.read(mzml_file)
-            param_groups = {}
-            for ref in mzml_object.iterfind("referenceableParamGroupList/referenceableParamGroup"):
-                param_groups[ref['id']] = ref
-        with gzip.open(input, 'rb') as mzmlgz_file:
-            with mzml.read(mzmlgz_file) as reader:
-                for s in reader:
-                    ms_level = s.get('ms level')
-                    if not ms_level:
-                        spec_param_group = s.get('ref')
-                        if spec_param_group:
-                            ms_level = param_groups[spec_param_group].get('ms level')
-                        elif args.default_ms_level:
-                            ms_level = args.default_ms_level
-                        else:
-                            raise Exception("No ms level found and no default for input.")
-                    # Always use given nativeID for mzML
-                    spectra.append(Spectrum(s['id'],int(ms_level),-1 if int(ms_level) == 1 else ms2plus_scan_idx))
-                    # Increment MS2+ counter, if spectrum was MS2+
-                    if int(ms_level) > 1:
-                        ms2plus_scan_idx += 1
+        try:
+            with gzip.open(input, 'rb') as mzmlgz_file:
+                mzml_object = mzml.read(mzml_file)
+                param_groups = {}
+                for ref in mzml_object.iterfind("referenceableParamGroupList/referenceableParamGroup"):
+                    param_groups[ref['id']] = ref
+            with gzip.open(input, 'rb') as mzmlgz_file:
+                with mzml.read(mzmlgz_file) as reader:
+                    for s in reader:
+                        ms_level = s.get('ms level')
+                        if not ms_level:
+                            spec_param_group = s.get('ref')
+                            if spec_param_group:
+                                ms_level = param_groups[spec_param_group].get('ms level')
+                            elif args.default_ms_level:
+                                ms_level = args.default_ms_level
+                            else:
+                                raise Exception("No ms level found and no default for input.")
+                        # Always use given nativeID for mzML
+                        spectra.append(Spectrum(s['id'],int(ms_level),-1 if int(ms_level) == 1 else ms2plus_scan_idx))
+                        # Increment MS2+ counter, if spectrum was MS2+
+                        if int(ms_level) > 1:
+                            ms2plus_scan_idx += 1
+        except Error as e:
+            if suppress_errors:
+                raise("{} is an malformatted {} file.".format(input,input_filetype))
+            else:
+                raise e
     elif input_filetype == '.mgf':
         all_scan_idx = 0
         with open(input) as mgf_file:

--- a/tools/generate_spectrum_index/generate_spectrum_index.py
+++ b/tools/generate_spectrum_index/generate_spectrum_index.py
@@ -51,9 +51,9 @@ def main():
                             ms2plus_scan_idx += 1
         except Error as e:
             if suppress_errors:
-                print("{} is an malformatted {} file.".format(input,input_filetype))
+                raise Exception("{} is an malformatted {} file.".format(input,input_filetype))
             else:
-                raise e
+                raise Exception(e)
     elif input_filetype == '.mzML':
         try:
             with open(input, 'rb') as mzml_file:
@@ -80,9 +80,9 @@ def main():
                             ms2plus_scan_idx += 1
         except Error as e:
             if suppress_errors:
-                raise("{} is an malformatted {} file.".format(input,input_filetype))
+                raise Exception("{} is an malformatted {} file.".format(input,input_filetype))
             else:
-                raise e
+                raise Exception(e)
     elif input_filetype == '.mzML.gz':
         try:
             with gzip.open(input, 'rb') as mzmlgz_file:
@@ -109,9 +109,9 @@ def main():
                             ms2plus_scan_idx += 1
         except Error as e:
             if suppress_errors:
-                raise("{} is an malformatted {} file.".format(input,input_filetype))
+                raise Exception("{} is an malformatted {} file.".format(input,input_filetype))
             else:
-                raise e
+                raise Exception(e)
     elif input_filetype == '.mgf':
         all_scan_idx = 0
         with open(input) as mgf_file:

--- a/tools/generate_spectrum_index/generate_spectrum_index.py
+++ b/tools/generate_spectrum_index/generate_spectrum_index.py
@@ -2,7 +2,6 @@ from pyteomics import mzxml, mzml, mgf
 from collections import namedtuple
 import csv
 import argparse
-import subprocess
 import sys
 from pathlib import Path
 import gzip
@@ -139,12 +138,15 @@ def main():
 
                         if ms_level > 1:
                             ms2plus_scan_idx += 1
-        # if that didn't work, just grep for total spectrum count
+        # if that didn't work, just count spectra in the file (marked by lines containing the word "BEGIN")
         except:
-            spectra = []
-            process = subprocess.run(['grep', '-c', 'BEGIN', args.input_spectrum], stdout=subprocess.PIPE)
-            ms2_count = int(process.communicate()[0])
+            ms2_count = 0
+            with open(input) as mgf_file:
+                for line in mgf_file:
+                    if "BEGIN" in line:
+                        ms2_count += 1
             # assume all spectra are MS level 2 and write out one row for each
+            spectra = []
             for index in range(0, ms2_count):
                 spectra.append(Spectrum('index={}'.format(index), 2, index))
 


### PR DESCRIPTION
Added a fallback to just grep MGF files for spectrum count and assume all spectra are MS level 2 in the event that the pyteomics parser fails.