### PR TITLE
Add re-mangling option for MassIVE-complete workflow

### DIFF
--- a/tools/generate_spectrum_index/demangle_collection.py
+++ b/tools/generate_spectrum_index/demangle_collection.py
@@ -59,8 +59,7 @@ def main():
             if args.preserve_suffix:
                 suffix = input_file.suffix
                 input_file_no_suffix = input_file.with_suffix('').name
-                output_file = demangled_mapping.get(input_file_no_suffix)
-                output_file = output_file.with_suffix(output_file.suffix + suffix)
+                output_file = demangled_mapping.get(input_file_no_suffix).with_suffix(suffix)
             else:
                 output_file = demangled_mapping.get(input_file.name)
         else:

--- a/tools/generate_spectrum_index/generate_spectrum_index.py
+++ b/tools/generate_spectrum_index/generate_spectrum_index.py
@@ -48,7 +48,7 @@ def main():
     #last extension so to match the downstream code,
     #we just remove the final suffix
 
-    output = Path(args.output_folder).joinpath(args.input_spectrum.with_suffix('.scans').name)
+    output = Path(args.output_folder).joinpath(args.input_spectrum.with_suffix(args.input_spectrum.suffix + '.scans').name)
     input_filetype = input_filetype.lower()
     if args.error_folder and args.error_folder.is_dir():
         output_err = Path(args.error_folder).joinpath(args.input_spectrum.name)
@@ -189,7 +189,7 @@ def main():
         # try to parse this mgf file with the pyteomics library
         try:
             all_scan_idx = 0
-            with gzip.open(args.input_spectrum) as mgf_gz_file:
+            with gzip.open(args.input_spectrum, 'rt') as mgf_gz_file:
                 with mgf.read(mgf_gz_file) as reader:
                     for s in reader:
                         # Check for MSLEVEL but assume 2
@@ -214,7 +214,7 @@ def main():
         except:
             try:
                 ms2_count = 0
-                with gzip.open(args.input_spectrum) as mgf_gz_file:
+                with gzip.open(args.input_spectrum, 'rt') as mgf_gz_file:
                     for i,line in enumerate(mgf_gz_file):
                         if "BEGIN" in line:
                             ms2_count += 1


### PR DESCRIPTION
Demangle collection script can now remangle a folder if `--reverse` is used as an input flag.  Further, if the folder has been altered with an added suffix, that suffix can be preserved using the `--preserve_suffix` flag.

Also fixes an error with mgf.gz where the file needed to be read in `rt` mode (`r` mode for gzip.open() reverts to `rb`)