### PR TITLE
Fixed command line token quoting bug

### DIFF
--- a/tools/generate_spectrum_index/massive_wrapper.py
+++ b/tools/generate_spectrum_index/massive_wrapper.py
@@ -50,7 +50,7 @@ def main():
             shutil.copy(cached_scans_file, str(output))
         else:
             print("No cached scans file cound be found for input spectrum file [" + input_spectrum  + "] - generating now.")
-            command = sys.executable + " " + GENERATE_SPECTRUM_INDEX_SCRIPT + " -i " + input_spectrum + " -o " + str(args.output_folder)
+            command = sys.executable + " \"" + GENERATE_SPECTRUM_INDEX_SCRIPT + "\" -i \"" + input_spectrum + "\" -o \"" + str(args.output_folder) + "\""
             if args.error_folder:
                 command += " -e " + str(args.error_folder)
             if args.default_ms_level:


### PR DESCRIPTION
Fixed a bug in `massive_wrapper.py` in which command line tokens were not properly quoted when executing the child scan extraction process.

There is probably a better way to build a subprocess command line than concatenating the entire command into a single string and using `shell=True` in the `subprocess.run()` call, but this is a quick and dirty solution that works properly now with this fix.

Confirmed working on massive:

https://massive.ucsd.edu/ProteoSAFe/status.jsp?task=c31eecf0e63e4bd2ad32132cc83cdb8a
(Reanalysis attachment that failed due to this bug, caused by whitespace in peak list filenames)

https://massive.ucsd.edu/ProteoSAFe/status.jsp?task=4cb4cc7719db41fcbf86033dfc03ee0e
(Same reanalysis attachment with bug fix, finished successfully)